### PR TITLE
Syntax errors have no associated linters

### DIFF
--- a/lib/scss_lint/reporters/codeclimate_reporter.rb
+++ b/lib/scss_lint/reporters/codeclimate_reporter.rb
@@ -3,9 +3,10 @@ module SCSSLint
 
     def report_lints
       lints.map do |lint|
+        linter_name = lint.linter ? lint.linter.name : "Error"
         {
           type: "issue",
-          check_name: lint.linter.name,
+          check_name: linter_name,
           description: lint.description,
           categories: ["Style"],
           remediation_points: 50_000,


### PR DESCRIPTION
Let's use the default name of `Error` for these cases
