### PR TITLE
Update `scss-lint` dependency to `0.42.2`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "scss_lint", '0.40.1', require: false
+gem "scss_lint", '0.42.2', require: false
 
 group :development do
   gem "pry", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,10 +21,10 @@ GEM
     rainbow (2.0.0)
     rake (10.4.2)
     ruby-progressbar (1.7.5)
-    sass (3.4.15)
-    scss_lint (0.40.1)
+    sass (3.4.18)
+    scss_lint (0.42.2)
       rainbow (~> 2.0)
-      sass (~> 3.4.1)
+      sass (~> 3.4.15)
     slop (3.6.0)
 
 PLATFORMS
@@ -36,4 +36,7 @@ DEPENDENCIES
   mocha
   pry
   rake
-  scss_lint (= 0.40.1)
+  scss_lint (= 0.42.2)
+
+BUNDLED WITH
+   1.10.6

--- a/test/scss_lint/reporters/test_codeclimate_reporter.rb
+++ b/test/scss_lint/reporters/test_codeclimate_reporter.rb
@@ -8,7 +8,7 @@ class TestCodeclimateReporter < Minitest::Test
       description: "`0px` should be written without units as `0`",
       filename: "test.scss"
     )
-    output = SCSSLint::Reporter::CodeclimateReporter.new([lint]).report_lints
+    output = SCSSLint::Reporter::CodeclimateReporter.new([lint], []).report_lints
     output_hash = JSON.parse(output)
     assert_equal "issue", output_hash["type"]
     assert_equal "BorderZero", output_hash["check_name"]


### PR DESCRIPTION
`scss-lint` has received a lot of fixes since the `0.40.1` release from June and would be interesting to have them available on the engine as well.
