### PR TITLE
Use include_paths instead of exclude_paths

### DIFF
--- a/lib/cc/engine/scss-lint.rb
+++ b/lib/cc/engine/scss-lint.rb
@@ -27,14 +27,12 @@ module CC
       attr_accessor :directory, :engine_config, :cli
 
       def scss_lint_options
-        excluded_files = Array(engine_config["exclude_paths"])
         options = {
           reporters: [
             ["Codeclimate", :stdout]
           ],
           required_paths: [], # the codeclimate report is required above
-          files: [], # execute SCSSLint::CLI in the `directory` path
-          excluded_files: excluded_files
+          files: sanitized_include_paths
         }
 
         if engine_config["config"]
@@ -46,6 +44,12 @@ module CC
 
       def parse_config(config_path)
         File.exists?(config_path) ? JSON.parse(File.read(config_path)) : {}
+      end
+
+      def sanitized_include_paths
+        Array(engine_config["include_paths"]).select do |path|
+          path.end_with?("/") || path.end_with?(".scss")
+        end
       end
 
     end

--- a/test/cc/engine/test_scss-lint.rb
+++ b/test/cc/engine/test_scss-lint.rb
@@ -6,8 +6,7 @@ class TestSCSSLint < Minitest::Test
       has_entries(
         reporters: [["Codeclimate", :stdout]],
         required_paths: [],
-        files: [],
-        excluded_files: []
+        files: []
       )
     )
 
@@ -19,12 +18,21 @@ class TestSCSSLint < Minitest::Test
       has_entries(
         reporters: [["Codeclimate", :stdout]],
         required_paths: [],
-        files: [],
-        excluded_files: ['somefile.scss']
+        files: ["somefile.scss", "a_dir/"]
       )
     )
 
-    with_config_file_contents('{"exclude_paths":["somefile.scss"]}') do |path|
+    config_contents = <<-JSON
+    {
+      "include_paths": [
+        "somefile.scss",
+        "a_dir/",
+        "not-scss.rb"
+      ]
+    }
+    JSON
+
+    with_config_file_contents(config_contents) do |path|
       CC::Engine::SCSSLint.new(directory: File.dirname(__FILE__), config_path: path).run
     end
   end
@@ -35,7 +43,6 @@ class TestSCSSLint < Minitest::Test
         reporters: [["Codeclimate", :stdout]],
         required_paths: [],
         files: [],
-        excluded_files: [],
         config_file: "somefile.scss"
       )
     )


### PR DESCRIPTION
Hi @ivantsepp,

I'm an engineer with CodeClimate. Our platform is deprecating the `exclude_paths` key in engine config, and is passing `include_paths` to engines instead.

This is a small patch to switch around the behavior for this engine to support the newer key.

There are some more details on the `include_paths` key in [the spec](https://github.com/codeclimate/spec/blob/master/SPEC.md#which-files-to-analyze) now. Let me know if you have any questions.

Thanks!
