### PR TITLE
Update scss-lint & sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "scss_lint", '0.42.2', require: false
+gem "scss_lint", '0.47.1', require: false
 
 group :development do
   gem "pry", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,12 +18,11 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rainbow (2.0.0)
     rake (10.4.2)
     ruby-progressbar (1.7.5)
-    sass (3.4.18)
-    scss_lint (0.42.2)
-      rainbow (~> 2.0)
+    sass (3.4.22)
+    scss_lint (0.47.1)
+      rake (>= 0.9, < 11)
       sass (~> 3.4.15)
     slop (3.6.0)
 
@@ -36,7 +35,7 @@ DEPENDENCIES
   mocha
   pry
   rake
-  scss_lint (= 0.42.2)
+  scss_lint (= 0.47.1)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/cc/engine/scss-lint.rb
+++ b/lib/cc/engine/scss-lint.rb
@@ -9,7 +9,7 @@ module CC
       def initialize(directory:, config_path:, io: STDOUT)
         self.directory = directory
         self.engine_config = parse_config(config_path)
-        self.cli = ::SCSSLint::CLI.new
+        self.cli = ::SCSSLint::CLI.new(::SCSSLint::Logger.new(STDERR))
       end
 
       def run

--- a/lib/scss_lint/reporters/codeclimate_reporter.rb
+++ b/lib/scss_lint/reporters/codeclimate_reporter.rb
@@ -2,9 +2,9 @@ module SCSSLint
   class Reporter::CodeclimateReporter < Reporter
 
     def report_lints
-      lints.map do |lint|
+      lints.each do |lint|
         linter_name = lint.linter ? lint.linter.name : "Error"
-        {
+        issue_json = {
           type: "issue",
           check_name: linter_name,
           description: lint.description,
@@ -24,7 +24,9 @@ module SCSSLint
             }
           }
         }.to_json
-      end.join("\0")
+        $stdout.print("#{issue_json}\0")
+      end
+      nil
     end
 
   end

--- a/test/scss_lint/reporters/test_codeclimate_reporter.rb
+++ b/test/scss_lint/reporters/test_codeclimate_reporter.rb
@@ -8,8 +8,10 @@ class TestCodeclimateReporter < Minitest::Test
       description: "`0px` should be written without units as `0`",
       filename: "test.scss"
     )
-    output = SCSSLint::Reporter::CodeclimateReporter.new([lint], []).report_lints
-    output_hash = JSON.parse(output)
+    output, _ = capture_io do
+      SCSSLint::Reporter::CodeclimateReporter.new([lint], [], ::SCSSLint::Logger.new($stderr)).report_lints
+    end
+    output_hash = JSON.parse(output.strip)
     assert_equal "issue", output_hash["type"]
     assert_equal "BorderZero", output_hash["check_name"]
     assert_equal "`0px` should be written without units as `0`", output_hash["description"]
@@ -20,5 +22,20 @@ class TestCodeclimateReporter < Minitest::Test
     end_position = {"line"=>1, "column"=>6}
     assert_equal start_position, output_hash["location"]["positions"]["begin"]
     assert_equal end_position, output_hash["location"]["positions"]["end"]
+  end
+
+  def capture_io
+    previous_stdout = $stdout
+    previous_stderr = $stderr
+
+    $stdout = stdout = StringIO.new
+    $stderr = stderr = StringIO.new
+
+    yield
+
+    [stdout.string, stderr.string]
+  ensure
+    $stdout = previous_stdout
+    $stderr = previous_stderr
   end
 end


### PR DESCRIPTION
Updating to the latest versions of these gems to get some recent
bugfixes & feature improvements.

scss-lint's API changed in several key ways, which necessitated a
somewhat ugly hack here:
- `SCSSLint::CLI` now requires a `logger` when being initialized: this
  logger is used for output for the the remainder of the run.
- Code Climate requires that stdout only contain issue JSON, while
  stderr may be used for other messages engines may wish to emit.
  Unfortunately, the `SCSSLint` logger takes a single IO channel, and
  uses it for everything.
  
  To work around this, I've changed the `CodeclimateReporter` class to
  emit issues directly to stdout, and then ensure the `report_lints`
  method returns `nil` so that the internal `SCSSLint::CLI` logic won't
  do anything.
