### PR TITLE
Fix handling include paths when they don't include SCSS

### DIFF
--- a/test/cc/engine/test_scss-lint.rb
+++ b/test/cc/engine/test_scss-lint.rb
@@ -6,7 +6,7 @@ class TestSCSSLint < Minitest::Test
       has_entries(
         reporters: [["Codeclimate", :stdout]],
         required_paths: [],
-        files: []
+        files: ["./"]
       )
     )
 
@@ -37,12 +37,26 @@ class TestSCSSLint < Minitest::Test
     end
   end
 
+  def test_skip_run_if_no_files_to_analyze
+    ::SCSSLint::CLI.any_instance.expects(:act_on_options).never
+
+    config_contents = <<-JSON
+    {
+      "include_paths": ["not-scss.rb"]
+    }
+    JSON
+
+    with_config_file_contents(config_contents) do |path|
+      CC::Engine::SCSSLint.new(directory: File.dirname(__FILE__), config_path: path).run
+    end
+  end
+
   def test_run_invokes_cli_with_config
     ::SCSSLint::CLI.any_instance.expects(:act_on_options).with(
       has_entries(
         reporters: [["Codeclimate", :stdout]],
         required_paths: [],
-        files: [],
+        files: ["./"],
         config_file: "somefile.scss"
       )
     )


### PR DESCRIPTION
The filtering I wrote to sanitize the include paths was a bit dumb: if
the include paths were purely non-SCSS related files (like, say, a list
of Ruby files), then it would filter down to an empty list, which would
be get passed to SCSS itself and be interpreted as "lint everything".

The fix here is to behave more similarly to other engines: `["./"]` is
provided as a default set of include paths, and is presumed as a value
if no other value is available. If the sanitized set of paths is empty,
SCSS is simply not run.

There was a related bug here with file extensions: SCSSLint handles
`.css` files in addition to `.scss`, but `#sanitize_include_paths` was
only looking for the `.scss` file extension. I've fixed that filtering
code to pull in the list of allowed extensions directly from SCSSLint.

@GordonDiggs you have a sec to review?

@ivantsepp Would you mind making me a contributor on this repo? I think I'm becoming one of the internal Code Climate team members who's likely to look into issues.
