### PR TITLE
Bump scss_lint version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "scss_lint", '0.52.0', require: false
+gem "scss_lint", '0.54.0', require: false
 
 group :development do
   gem "pry", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,8 +20,8 @@ GEM
       slop (~> 3.4)
     rake (10.4.2)
     ruby-progressbar (1.7.5)
-    sass (3.4.23)
-    scss_lint (0.52.0)
+    sass (3.4.25)
+    scss_lint (0.54.0)
       rake (>= 0.9, < 13)
       sass (~> 3.4.20)
     slop (3.6.0)
@@ -35,7 +35,7 @@ DEPENDENCIES
   mocha
   pry
   rake
-  scss_lint (= 0.52.0)
+  scss_lint (= 0.54.0)
 
 BUNDLED WITH
    1.14.3


### PR DESCRIPTION
Tests pass. Not sure what else I should check – please let me know what else I can do.

Between 0.52.0 and 0.54.0, `scss_lint` has been updated to support a few things like ([relevant to me](https://codeclimate.com/github/bensaufley/code-words-web/issues)) CSS Grid properties.

Thanks for maintaining this!