### PR TITLE
Update scss_lint to 0.57.1 (or anything >= 0.55)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "scss_lint", '0.54.0', require: false
+gem "scss_lint", '0.57.1', require: false
 
 group :development do
   gem "pry", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     ansi (1.5.0)
     builder (3.2.2)
     coderay (1.1.0)
+    ffi (1.9.25)
     metaclass (0.0.4)
     method_source (0.8.2)
     minitest (5.7.0)
@@ -19,11 +20,18 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rake (10.4.2)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     ruby-progressbar (1.7.5)
-    sass (3.4.25)
-    scss_lint (0.54.0)
+    sass (3.7.2)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    scss_lint (0.57.1)
       rake (>= 0.9, < 13)
-      sass (~> 3.4.20)
+      sass (~> 3.5, >= 3.5.5)
     slop (3.6.0)
 
 PLATFORMS
@@ -35,7 +43,7 @@ DEPENDENCIES
   mocha
   pry
   rake
-  scss_lint (= 0.54.0)
+  scss_lint (= 0.57.1)
 
 BUNDLED WITH
-   1.14.3
+   1.17.1


### PR DESCRIPTION
It would be great to have `ng-deep` on the PseudoElement whitelist. As this is hard-coded in scss_lint, i'm opening a request for update here.
Cheers!
Marian

https://github.com/brigade/scss-lint/commit/eac1143f474dafb2c7cd1ebb7adb8f7e2bdc6e3a