### PR TITLE
Bump scss_lint to 0.58.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
+  - 2.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codeclimate/alpine-ruby:b38
+FROM ruby:2-alpine
 
 WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app/

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "scss_lint", '0.54.0', require: false
+gem "scss_lint", '0.59.0', require: false
 
 group :development do
   gem "pry", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     ansi (1.5.0)
     builder (3.2.2)
     coderay (1.1.0)
+    ffi (1.11.1)
     metaclass (0.0.4)
     method_source (0.8.2)
     minitest (5.7.0)
@@ -19,11 +20,17 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rake (10.4.2)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     ruby-progressbar (1.7.5)
-    sass (3.4.25)
-    scss_lint (0.54.0)
-      rake (>= 0.9, < 13)
-      sass (~> 3.4.20)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    scss_lint (0.59.0)
+      sass (~> 3.5, >= 3.5.5)
     slop (3.6.0)
 
 PLATFORMS
@@ -35,7 +42,7 @@ DEPENDENCIES
   mocha
   pry
   rake
-  scss_lint (= 0.54.0)
+  scss_lint (= 0.59.0)
 
 BUNDLED WITH
-   1.14.3
+   1.14.4


### PR DESCRIPTION
Replacing #19, since there are now newer releases.